### PR TITLE
Cleanup after build to keep the image lightweight

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ ENV VERSION 0.2.5.10
 RUN apt-get update && apt-get install -y \
    build-essential \
    curl \
+   libevent-2.0-5 \
+   libssl1.0.0 \
    libevent-dev \
    libssl-dev
 
@@ -20,8 +22,12 @@ ADD ./torrc /etc/torrc
 # Allow you to upgrade your relay without having to regenerate keys
 VOLUME /.tor
 
+RUN apt-get -y remove build-essential libevent-dev libssl-dev
+RUN apt-get -y autoremove
+
 
 # Generate a random nickname for the relay
 RUN echo "Nickname docker$(head -c 16 /dev/urandom  | sha1sum | cut -c1-10)" >> /etc/torrc
 
 CMD /usr/local/bin/tor -f /etc/torrc
+


### PR DESCRIPTION
By specifying the binary libraries and removing build-essentials and dependencies after the build is complete, the image is lighter by several megabytes.