### PR TITLE
Securely install Tor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,28 @@ RUN apt-get update && apt-get install -y \
    libevent-dev \
    libssl-dev
 
-RUN curl https://dist.torproject.org/tor-${VERSION}.tar.gz | tar xz -C /tmp
+# Get signing keys securely
+# Ref: https://www.torproject.org/docs/signing-keys.html.en
+RUN mkdir /tmp/gpg
+RUN chmod 700 /tmp/gpg
+# Roger Dingledine
+RUN gpg --homedir /tmp/gpg --keyserver keys.gnupg.net --recv 19F78451
+RUN gpg --homedir /tmp/gpg --export F65CE37F04BA5B360AE6EE17C218525819F78451 | gpg --import -
+# Nick Mathewson
+RUN gpg --homedir /tmp/gpg --keyserver keys.gnupg.net --recv 165733EA
+RUN gpg --homedir /tmp/gpg --export B35BF85BF19489D04E28C33C21194EBB165733EA | gpg --import -
+RUN rm -rf /tmp/gpg
+
+WORKDIR /tmp/
+
+RUN curl https://dist.torproject.org/tor-${VERSION}.tar.gz > tor.tar.gz
+RUN curl https://dist.torproject.org/tor-${VERSION}.tar.gz.asc > tor.tar.gz.asc
+
+# Verify source tarball
+RUN gpg --verify tor.tar.gz.asc
+
+RUN tar xzf tor.tar.gz
+RUN rm tor.tar.gz tor.tar.gz.asc
 
 WORKDIR /tmp/tor-${VERSION}
 RUN ./configure

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,10 @@ RUN apt-get update && apt-get install -y \
 
 RUN curl https://dist.torproject.org/tor-${VERSION}.tar.gz | tar xz -C /tmp
 
-RUN cd /tmp/tor-${VERSION} && ./configure
-RUN cd /tmp/tor-${VERSION} && make
-RUN cd /tmp/tor-${VERSION} && make install
+WORKDIR /tmp/tor-${VERSION}
+RUN ./configure
+RUN make
+RUN make install
 
 ADD ./torrc /etc/torrc
 # Allow you to upgrade your relay without having to regenerate keys

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+#!/bin/bash
+build:
+	docker build -t tor-server .
+run:
+	docker rm -f tor-server 2> /dev/null; docker run -d --name tor-server tor-server


### PR DESCRIPTION
Check the tor tarball with appropriate signing keys to ensure authenticity of the download.

The reason for the /tmp/gpg directory is to silo off keys we're not sure about, since we download with the (still) insecure `gpg --recv-keys <short-key-id>` - see https://evil32.com/.  Even though this has been patched in latest versions of GPG, the packages in Ubuntu have yet to catch up.

With `--export <fingerprint>`, we can be sure we're selecting by the entire key, which is imported to the keyring we actually verify with.  If the verify fails, `docker build` will halt.

I also have the slim version of this, which is to run all the download and build steps in a single `Dockerfile` command, available at https://github.com/Hainish/docker-tor/tree/slim.  This may be desirable for those downloading the docker image based on filesize.  It also may be undesirable for those building manually, if some intermediate step fails they can't easily re-run.  For this reason I haven't included it in this PR.