### PR TITLE
Updated to tor 0.2.5.11 from deb package and switched to Debian jessie. Closes #8.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,31 @@
-FROM ubuntu
+FROM debian:jessie
+
 MAINTAINER "Patrick O'Doherty <p@trickod.com>"
 
 EXPOSE 9001
-ENV VERSION 0.2.5.10
+ENV DEBIAN_FRONTEND noninteractive
 
+ADD apt-pinning /etc/apt/preferences.d/pinning
+RUN echo 'deb http://deb.torproject.org/torproject.org jessie main' > /etc/apt/sources.list.d/tor.list && \
+    gpg --keyserver keys.gnupg.net --recv 886DDD89 && \
+    gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | apt-key add -
 RUN apt-get update && apt-get install -y \
-   build-essential \
-   curl \
-   libevent-dev \
-   libssl-dev
+    deb.torproject.org-keyring \
+    obfsproxy \
+    openssl \
+    tor
 
-RUN curl https://dist.torproject.org/tor-${VERSION}.tar.gz | tar xz -C /tmp
+# tor-arm does not work in Docker container:
+# _curses.error: setupterm: could not find terminal
+# Install outside of the Docker container if required.
 
-RUN cd /tmp/tor-${VERSION} && ./configure
-RUN cd /tmp/tor-${VERSION} && make
-RUN cd /tmp/tor-${VERSION} && make install
+WORKDIR /var/lib/tor
 
 ADD ./torrc /etc/torrc
 # Allow you to upgrade your relay without having to regenerate keys
-VOLUME /.tor
-
+VOLUME /var/lib/tor
 
 # Generate a random nickname for the relay
 RUN echo "Nickname docker$(head -c 16 /dev/urandom  | sha1sum | cut -c1-10)" >> /etc/torrc
 
-CMD /usr/local/bin/tor -f /etc/torrc
+CMD /usr/bin/tor -f /etc/torrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,9 @@ WORKDIR /var/lib/tor
 
 ADD ./torrc /etc/torrc
 # Allow you to upgrade your relay without having to regenerate keys
-VOLUME /var/lib/tor
+# VOLUME /var/lib/tor
+
+VOLUME /.tor
 
 # Generate a random nickname for the relay
 RUN echo "Nickname docker$(head -c 16 /dev/urandom  | sha1sum | cut -c1-10)" >> /etc/torrc

--- a/apt-pinning
+++ b/apt-pinning
@@ -1,0 +1,3 @@
+Package: *
+Pin: origin "deb.torproject.org"
+Pin-Priority: 800

--- a/torrc
+++ b/torrc
@@ -1,6 +1,7 @@
 Log notice stdout
 ExitPolicy reject *:*
 # User debian-tor
-DataDirectory /var/lib/tor
+# DataDirectory /var/lib/tor
+DataDirectory /root/.tor
 ORPort 9001
-
+#

--- a/torrc
+++ b/torrc
@@ -1,4 +1,6 @@
 Log notice stdout
 ExitPolicy reject *:*
+# User debian-tor
+DataDirectory /var/lib/tor
 ORPort 9001
 


### PR DESCRIPTION
Anything I overlooked why building from source is preferred?

* Debian is the recommended base image for Docker.
  See https://docs.docker.com/articles/dockerfile_best-practices/#from
* Debian stable is normally preferred in regards to security but the current version of tor from deb.torproject.org can not be used with stable:

        The following packages have unmet dependencies:
         tor : Depends: libc6 (>= 2.14) but 2.13-38+deb7u8 is to be installed
               Depends: libseccomp2 (>= 0.0.0~20120605) but it is not installable

* Changed volume of tor home dir to the default one /var/lib/tor.
  Note that when I do `docker rm … && docker run …` docker will not use
  the previously used volume but instead create a new container
  resulting in a new private key being generated.
  I use `docker run -v /srv/tor:/var/lib/tor` for persistent storage.
* https://www.torproject.org/docs/debian.html.en
* apt automatically checks packages with GPG. Related to #8. Note that #8 also includes a Makefile, which you might want to cherry-pick.
* Using apt_preferences to ensure that packages from deb.torproject.org are
  preferred. Without this, all packages are installed from the Debian repository.
  See `man apt_preferences`.
* One could also run tor inside the Docker container as debian-tor user.
  But note that the UID of debian-tor might be mapped to a different user
  outside of the container resulting in read+write access for this user
  to the private key.